### PR TITLE
Implemented pose recording to CSV file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 opencv*/
+recordings/

--- a/include/tracker.hpp
+++ b/include/tracker.hpp
@@ -128,6 +128,9 @@ std::stringstream createTimeStampedFileName(
   const std::string& prefix,
   const std::string& extension);
 
-void trackLineFollower(const detectionOptions& options);
+void trackLineFollower(
+  const detectionOptions& options,
+  const std::string& output_file = "none");
+
 void calibrateCamera(const calibrationOptions& options, const calibrationOutput& output);
 }

--- a/include/tracker.hpp
+++ b/include/tracker.hpp
@@ -117,7 +117,10 @@ void writeConfigFile(
   const calibrationOptions& calibration_options,
   const calibrationOutput& calibration_output);
 
-std::stringstream createConfigFileName(const std::string& filedir);
+std::stringstream createTimeStampedFileName(
+  const std::string& filedir,
+  const std::string& prefix,
+  const std::string& extension);
 
 void trackLineFollower(const detectionOptions& options);
 void calibrateCamera(const calibrationOptions& options, const calibrationOutput& output);

--- a/include/tracker.hpp
+++ b/include/tracker.hpp
@@ -39,6 +39,7 @@ the use of this software, even if advised of the possibility of such damage.
 #pragma once
 
 #include <iostream>
+#include <fstream>
 #include <ctime>
 
 #include <opencv2/highgui.hpp>
@@ -116,6 +117,11 @@ void writeConfigFile(
   const detectionOptions& detection_options,
   const calibrationOptions& calibration_options,
   const calibrationOutput& calibration_output);
+
+void writePoseToCSV(
+  std::ofstream& csv_file,
+  const cv::Vec3d& tvec,
+  const cv::Vec3d& rvec);
 
 std::stringstream createTimeStampedFileName(
   const std::string& filedir,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,15 @@ int main(int argc, char *argv[]) {
   if (!calibrationMode) {
     auto fileName {parser.get<std::string>("config")};
     tracker::readConfigFile(fileName, detectionOptions);
-    tracker::trackLineFollower(detectionOptions);
+
+    if (hasOutputDir) {
+      auto outputDir {parser.get<std::string>("output")};
+      auto fileName {tracker::createTimeStampedFileName(outputDir, "run", "csv")};
+      tracker::trackLineFollower(detectionOptions, fileName.str());
+    }
+    else {
+      tracker::trackLineFollower(detectionOptions);
+    }
   }
   else {
     if (hasConfigFile) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
 
       if (hasOutputDir) {
         auto outputDir {parser.get<std::string>("output")};
-        auto fileNameStream {tracker::createConfigFileName(outputDir)};
+        auto fileNameStream {tracker::createTimeStampedFileName(outputDir, "config", "yaml")};
         tracker::writeConfigFile(fileNameStream.str(), detectionOptions, calibrationOptions, calibrationOutput);
       }
       else {
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
       std::cout << "Creating a new config file in the output directory..." << std::endl;
       auto outputDir {parser.get<std::string>("output")};
 
-      auto fileNameStream {tracker::createConfigFileName(outputDir)};
+      auto fileNameStream {tracker::createTimeStampedFileName(outputDir, "config", "yaml")};
 
       tracker::writeConfigFile(fileNameStream.str(), detectionOptions, calibrationOptions, calibrationOutput);
       std::cout << "Config file created: " << fileNameStream.str() << std::endl;

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -141,6 +141,23 @@ void tracker::writePoseToCSV(
            << rvec[0] << ", " << rvec[1] << ", " << rvec[2] << std::endl;
 }
 
+void tracker::trackLineFollower(
+  const tracker::detectionOptions& options,
+  const std::string& output_file)
+{
+  bool hasOutputFile {output_file != "none"};
+  std::ofstream posesOutputFile;
+
+  if (hasOutputFile) {
+    posesOutputFile = std::ofstream(output_file);
+    if (!posesOutputFile.is_open())
+      throw Error::CANNOT_OPEN_FILE;
+  }
+  else {
+    std::cout << "No output directory given, poses will not be recorded."
+              << std::endl;
+  }
+
   cv::VideoCapture inputVideo;
   int waitTime;
 
@@ -215,6 +232,10 @@ void tracker::writePoseToCSV(
       // Calculate pose for each marker
       for (size_t  i = 0; i < nMarkers; i++) {
         cv::solvePnP(objPoints, corners.at(i), options.camMatrix, options.distCoeffs, rvecs.at(i), tvecs.at(i));
+
+        // Record the poses if there's an output file
+        if (hasOutputFile)
+          tracker::writePoseToCSV(posesOutputFile, tvecs.at(i), rvecs.at(i));
       }
     }
 

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -90,12 +90,17 @@ void tracker::readConfigFile(const std::string& filename, tracker::calibrationOp
   cv::read(dictionaryIDNode, options.arucoDictionaryID, cv::aruco::DICT_ARUCO_ORIGINAL);
 }
 
-std::stringstream tracker::createConfigFileName(const std::string& filedir)
+std::stringstream tracker::createTimeStampedFileName(
+  const std::string& filedir,
+  const std::string& prefix,
+  const std::string& extension)
 {
   std::stringstream filenameStream;
   std::time_t t = std::time(nullptr);
   std::tm tm = *std::localtime(&t);
-  filenameStream << filedir << "config-" << std::put_time(&tm, "%Y%m%d-%H%M%S") << ".yaml";
+  filenameStream << filedir << prefix << "-"
+                 << std::put_time(&tm, "%Y%m%d-%H%M%S")
+                 << "." << extension;
 
   return filenameStream;
 }

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <fstream>
 
 #include "tracker.hpp"
 
@@ -133,8 +132,15 @@ void tracker::writeConfigFile(
   configFile.release();
 }
 
-void tracker::trackLineFollower(const tracker::detectionOptions& options)
+void tracker::writePoseToCSV(
+  std::ofstream& csv_file,
+  const cv::Vec3d& tvec,
+  const cv::Vec3d& rvec)
 {
+  csv_file << tvec[0] << ", " << tvec[1] << ", " << tvec[2] << ", "
+           << rvec[0] << ", " << rvec[1] << ", " << rvec[2] << std::endl;
+}
+
   cv::VideoCapture inputVideo;
   int waitTime;
 


### PR DESCRIPTION
Output directory argument in tracking mode can now be used to record poses in a CSV file in that directory.

The generated CSV file has translation and rotation values of marker(s) in each frame. This could be updated to record only a specific marker ID in the future. 